### PR TITLE
Honor NoAutoOp/Voice when resyncing

### DIFF
--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -4535,8 +4535,9 @@ static CHANSERV_FUNC(cmd_resync)
 {
     struct mod_chanmode *changes;
     struct chanData *cData = channel->channel_info;
-    unsigned int ii, used;
+    unsigned int ii, used, force;
 
+    force = (argc > 1) && !irccasecmp(argv[1], "force");
     changes = mod_chanmode_alloc(channel->members.used * 2);
     for(ii = used = 0; ii < channel->members.used; ++ii)
     {
@@ -4547,6 +4548,10 @@ static CHANSERV_FUNC(cmd_resync)
             continue;
 
         uData = GetChannelAccess(cData, mn->user->handle_info);
+        /* Honor NoAutoOp */
+        if(!force && uData && !IsUserAutoOp(uData))
+            continue;
+
         if(!cData->lvlOpts[lvlGiveOps]
            || (uData && uData->access >= cData->lvlOpts[lvlGiveOps]))
         {

--- a/src/chanserv.help
+++ b/src/chanserv.help
@@ -317,8 +317,9 @@
 "REMOVENOTE" ("/msg $S REMOVENOTE <typename> [FORCE]",
         "Permanently deletes a note type.  Without the argument $bFORCE$b, it will only delete an unused note type.  With the argument $bFORCE$b, it will delete the note from all channels and then delete the note type.",
         "$uSee Also:$u createnote");
-"RESYNC" ("/msg $S RESYNC <#channel>",
-        "Synchronizes users in the channel with the userlist.  This means that if the user can normally get ops, $S makes sure the user has ops.  Otherwise, if the user normally gets voice, $S makes sure the user has voice but not ops.  Otherwise, $S makes sure the user has neither voice nor ops.");
+"RESYNC" ("/msg $S RESYNC <#channel> [FORCE]",
+        "Synchronizes users in the channel with the userlist.  This means that if the user can normally get ops, $S makes sure the user has ops.  Otherwise, if the user normally gets voice, $S makes sure the user has voice but not ops.  Otherwise, $S makes sure the user has neither voice nor ops.",
+        "$S will ignore users with NoAutoOp/Voice enabled unless the $bFORCE$b arugment is given.");
 "SAY" ("/msg $C SAY <#channel|nick|*account> <text>",
         "Makes $b$C$b send a message to the specified channel/nick or all users on the account.",
         "$uSee Also:$u emote");
@@ -478,7 +479,7 @@
          "The $buset$b command allows you to toggle various channel user settings. With no arguments, it will print the current values of all channel user options.",
          "$bOptions:$b",
          "INFO:       Sets the infoline that $C sends when you join the channel.",
-         "NOAUTOOP:   Enable or disable $C automatically opping you upon joining or authenticating.",
+         "NOAUTOOP:   Enable or disable $C automatically opping you upon joining, authenticating, or resyncing.",
 	 "AUTOINVITE: $C will invite you to this channel if you have access to and are not in when you authenticate if this setting is on.",
          "NOTE: The NoAutoOp setting is equivalent to the !togop command in previous versions of srvx.",
          "$uSee Also:$u set");


### PR DESCRIPTION
When resyncing, ChanServ ignores NoAuto*. In some cases this defeats the purpose of the user setting. My solution is to have ChanServ ignore users that have the setting enabled while only changing their status when the FORCE argument is given with !resync.