### PR TITLE
Change PICKUP's help entry to reflect its functionality

### DIFF
--- a/src/mod-helpserv.help
+++ b/src/mod-helpserv.help
@@ -7,7 +7,7 @@
 "QUEUE" ("Managing the request queue in $S",
         "  LIST        List open requests",
         "  NEXT        Pick up the next unassigned request",
-        "  PICKUP      Pick up a particular unassigned request",
+        "  PICKUP      Pick up a particular request",
         "  REASSIGN    Assign a request to another helper",
         "  CLOSE       Close out a request",
         "  SHOW        Show detailed information on a request",


### PR DESCRIPTION
HelpServ's PICKUP command is not specific towards whether the request is assigned or not; however, the help entry says it specific towards "unassigned" requests which is wrong.