### PR TITLE
Kick on nick change

### DIFF
--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -6853,9 +6853,6 @@ handle_nick_change(struct userNode *user, UNUSED_ARG(const char *old_nick))
         for(jj = 0; jj < channel->banlist.used; ++jj)
             if(user_matches_glob(user, channel->banlist.list[jj]->ban, MATCH_USENICK))
                 break;
-        /* Need not act if we found one. */
-        if(jj < channel->banlist.used)
-            continue;
         /* Look for a matching ban in this channel. */
         for(bData = channel->channel_info->bans; bData; bData = bData->next)
         {

--- a/src/chanserv.c
+++ b/src/chanserv.c
@@ -6858,8 +6858,11 @@ handle_nick_change(struct userNode *user, UNUSED_ARG(const char *old_nick))
         {
             if(!user_matches_glob(user, bData->mask, MATCH_USENICK | MATCH_VISIBLE))
                 continue;
-            change.args[0].u.hostmask = bData->mask;
-            mod_chanmode_announce(chanserv, channel, &change);
+            if(!(jj < channel->banlist.used))
+            {
+                change.args[0].u.hostmask = bData->mask;
+                mod_chanmode_announce(chanserv, channel, &change);
+            }
             sprintf(kick_reason, "(%s) %s", bData->owner, bData->reason);
             KickChannelUser(user, channel, chanserv, kick_reason);
             bData->triggered = now;


### PR DESCRIPTION
When a user changes their nick to one that matches a banned mask in SrvX, they are kicked if the ban mask is not present within the IRCd. However if it is present it's set to do nothing. I feel that this creates a bit of a continuity issue has users that joined under banned masks are kick banned, however since nick is the only thing that can change for a user, as well as a part of a ban mask, then even if the users was doing it unintentionally, it would leave them in a state of confusion such as "Why can't I change my nick? Why can't I talk, etc." since they are under a +b mask. Yes I do realize that they cannot change their nicks under +b but then it just makes the scenario feel like a fly trap. If the user joins, changes nick, and they ban already exists in the IRCd's ban list then they are inevitably polluting the channel with whatever nick the Channel Operators don't want. Yes, I realize that they could just rejoin under the new nick however if they constantly do this then I feel that the channel operator should take more responsibility in banning the user itself rather then just the nick. Besides, if they want to troll by parting, changing nicks, joining, rinse wash and repeat, then they will end up getting throttled by the IRCd for target changes which gives channel ops enough time to make more proper decisions.