### PR TITLE
opserv_cdiscrim_create(): Fix memory leak

### DIFF
--- a/src/opserv.c
+++ b/src/opserv.c
@@ -3626,7 +3626,7 @@ opserv_cdiscrim_create(struct userNode *user, unsigned int argc, char *argv[])
         /* Assume all criteria require arguments. */
         if (i == (argc - 1)) {
             send_message(user, opserv, "MSG_MISSING_PARAMS", argv[i]);
-            return NULL;
+            goto fail;
         }
 
         if (!irccasecmp(argv[i], "name"))


### PR DESCRIPTION
If opserv_cdiscrim_create()'s (used in CSEARCH) parameters are
not met, it returns NULL. However, the issue is that it should be
going to the fail statement rather than simply returning NULL.
This creates the issue that discrim is never freed, where fail frees
discrim and returns null in one shot.