### PR TITLE
opserv_discrim_create(): wrap argc - 1 in parentheses

### DIFF
--- a/src/opserv.c
+++ b/src/opserv.c
@@ -3019,7 +3019,7 @@ opserv_discrim_create(struct userNode *user, unsigned int argc, char *argv[], in
             continue;
         }
         /* Assume all other criteria require arguments. */
-        if (i == argc - 1) {
+        if (i == (argc - 1)) {
             send_message(user, opserv, "MSG_MISSING_PARAMS", argv[i]);
             goto fail;
         }


### PR DESCRIPTION
This is mostly to match the syntax of opserv_cdiscrim_create(), but it does help provide clarity.