### PR TITLE
blacklist: Fix potential memory leak

### DIFF
--- a/src/mod-blacklist.c
+++ b/src/mod-blacklist.c
@@ -122,7 +122,7 @@ dnsbl_hit(struct sar_request *req, struct dns_header *hdr, struct dns_rr *rr, un
             break;
         case REQ_TYPE_TXT:
             len = raw[pos];
-            txt = malloc(len + 1);
+            txt = realloc(txt, len + 1);
             memcpy(txt, raw + pos + 1, len);
             txt[len] = '\0';
             break;


### PR DESCRIPTION
Use realloc() instead. In the event we get multiple TXT records, we just reallocate on top of that instead of leaking the last result.