### PR TITLE
bahamut: Add missing implementation for irc_remote_oper

### DIFF
--- a/src/proto-bahamut.c
+++ b/src/proto-bahamut.c
@@ -269,6 +269,16 @@ irc_fakehost(UNUSED_ARG(struct userNode *user), UNUSED_ARG(const char *host), UN
 }
 
 void
+irc_remote_oper(struct userNode *target, int deoper)
+{
+    if (deoper) {
+        irc_svsmode(target, "-o", 0);
+    } else {
+        irc_svsmode(target, "+o", 0);
+    }
+}
+
+void
 irc_regnick(struct userNode *user)
 {
     if (IsReggedNick(user)) {


### PR DESCRIPTION
This now compiled with with `--with-protocol=bahamut`, but I haven't tested this against a bahamut server